### PR TITLE
Reduce the timeout used when testing timeout functionality

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -77,8 +77,8 @@ func TestRunSingleTestFailure(t *testing.T) {
 
 func TestRunSingleTestTimeout(t *testing.T) {
 	testFolder, _ := filepath.Abs("../testdata")
-	testResult := runSingleTest("timeout.sh", testFolder, 5*time.Second)
-	expectedOutput := "Stuck in an infinite loop!\nStuck in an infinite loop!\nKilled by testbrain: Timed out after 5s"
+	testResult := runSingleTest("timeout.sh", testFolder, 1*time.Second)
+	expectedOutput := "Stuck in an infinite loop!\nStuck in an infinite loop!\nStuck in an infinite loop!\nKilled by testbrain: Timed out after 1s"
 	expected := lib.TestResult{
 		TestFile: "timeout.sh",
 		Success:  false,

--- a/testdata/timeout.sh
+++ b/testdata/timeout.sh
@@ -3,6 +3,6 @@
 while true;
 do
     echo "Stuck in an infinite loop!"
-    sleep 3
+    sleep 0.4
 done
 echo "Goodbye World!"


### PR DESCRIPTION
This makes the test run finish slightly faster
