### PR TITLE
HCF-1167 make lint/format should fail on error

### DIFF
--- a/make/format
+++ b/make/format
@@ -4,20 +4,16 @@ set -o errexit
 
 . make/include/colors.sh
 
-echo "${OK_COLOR}==> Formatting ${ERROR_COLOR}"
+printf "%b==> Formatting %b\n" "${OK_COLOR}" "${ERROR_COLOR}"
+
 ISSUES=$(mktemp)
 
-trap "rm -f ${ISSUES}" HUP INT TERM
+trap "cat ${ISSUES} ; rm -f ${ISSUES}" EXIT
 
 go list -f '{{ .Dir }}' ./... | grep -v /vendor/ | while read DIR; do
-    goimports -d -e ${DIR}/*.go | tee -a ${ISSUES}
+    goimports -d -e "${DIR}"/*.go >> "${ISSUES}"
 done
 
-ISSUE_COUNT=$(cat ${ISSUES} | wc -l)
+printf "%b" "${NO_COLOR}"
 
-rm -f ${ISSUES}
-
-echo "${NO_COLOR}\c"
-
-test ${ISSUE_COUNT} -eq 0
-
+test ! -s "${ISSUES}"

--- a/make/lint
+++ b/make/lint
@@ -4,20 +4,16 @@ set -o errexit
 
 . make/include/colors.sh
 
-echo "${OK_COLOR}==> Linting${ERROR_COLOR}"
+printf "%b==> Linting%b\n" "${OK_COLOR}" "${ERROR_COLOR}"
 
 ISSUES=$(mktemp)
 
-trap "rm -f ${ISSUES}" HUP INT TERM
+trap "cat ${ISSUES} ; rm -f ${ISSUES}" EXIT
 
 go list -f '{{ .Dir }}' ./... | grep -v /vendor/ | while read DIR; do
-    golint ${DIR} | tee -a ${ISSUES}
+    golint "${DIR}" >> "${ISSUES}"
 done
 
-ISSUE_COUNT=$(cat ${ISSUES} | wc -l)
+printf "%b" "${NO_COLOR}"
 
-rm -f ${ISSUES}
-
-echo "${NO_COLOR}\c"
-test ${ISSUE_COUNT} -eq 0
-
+test ! -s "${ISSUES}"


### PR DESCRIPTION
When the program (golint / goimports) reports an error — for example because they were not installed - we should correctly fail.

This fixes the issue by getting rid of the pipe so `errexit` is still in effect.  While we're there, get rid of the `wc` too, since we can just test for an empty file.  That means always removing the file during the trap, rather than early, which lets us unconditionally cat it too.

Also fixes problems identified by shellcheck.