### PR TITLE
[HCF-1206] Provide the test brain's timeout configuration to the invoked script, via its environment.

### DIFF
--- a/lib/runner.go
+++ b/lib/runner.go
@@ -194,6 +194,13 @@ func (r *Runner) runSingleTest(testFile string, testFolder string) TestResult {
 	commandOutput := &bytes.Buffer{}
 	command.Stdout = commandOutput
 	command.Stderr = commandOutput
+
+	// Propagate timeout information from brain to script, via the
+	// environment of the script.
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("TESTBRAIN_TIMEOUT=%d", int(r.Timeout.Seconds())))
+	command.Env = env
+
 	err := command.Start()
 	if err != nil {
 		return ErrorTestResult(testFile, err)

--- a/lib/runner_test.go
+++ b/lib/runner_test.go
@@ -345,7 +345,8 @@ func TestRunSingleTestTimeout(t *testing.T) {
 
 	testFolder, _ := filepath.Abs("../testdata")
 	testResult := r.runSingleTest("timeout_test.sh", testFolder)
-	expectedOutput := "Stuck in an infinite loop!\n" +
+	expectedOutput := "Timeout = 1\n" +
+		"Stuck in an infinite loop!\n" +
 		"Stuck in an infinite loop!\n" +
 		"Stuck in an infinite loop!\n" +
 		"Killed by testbrain: Timed out after 1s"

--- a/testdata/timeout_test.sh
+++ b/testdata/timeout_test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-while true;
+echo Timeout = $TESTBRAIN_TIMEOUT
+while true
 do
     echo "Stuck in an infinite loop!"
     sleep 0.4


### PR DESCRIPTION
Passes linting, vetting, and extended unit tests.
hcf integration PR to be made.