### PR TITLE
Ability to skip a test during its execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Global Flags:
 ## Marking tests as skipped
 
 Sometimes a test may be marked as skipped, which indicates it didn't fail neither succeeded. It may
-happen, e.g., when external dependencies as not satisfied.
+happen, e.g., when external dependencies are not satisfied.
 
 Any test that returns the status code `99` will be marked as skipped. It allows the test itself to
 run checks to determine if it should skip or not.

--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ Global Flags:
 Sometimes a test may be marked as skipped, which indicates it didn't fail neither succeeded. It may
 happen, e.g., when external dependencies as not satisfied.
 
-Any test that returns the status code `200` will be marked as skipped. It allows the test itself to
+Any test that returns the status code `99` will be marked as skipped. It allows the test itself to
 run checks to determine if it should skip or not.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Global Flags:
 
 ## Marking tests as skipped
 
-Sometimes a test may be marked as skipped, which indicates it didn't fail neither succeeded. It may
+Sometimes a test may be marked as skipped, which indicates it neither failed nor succeeded. It may
 happen, e.g., when external dependencies are not satisfied.
 
 Any test that returns the status code `99` will be marked as skipped. It allows the test itself to

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # testbrain: Acceptance Test Brain
 
-Simple test runner. Runs all bash tests in the designated test folder, gathering results and outputs and summarizing it.
+Simple test runner. Runs all bash tests in the designated test folder, gathering results and outputs
+and summarizing it.
 
-Currently, only one command is available: 
+Currently, only one command is available:
 
 ### `testbrain run`
 Runs all tests in the test folder.
@@ -13,7 +14,8 @@ Usage:
 
 Flags:
   -n, --dry-run          Do not actually run the tests
-      --exclude string   Regular expression of subset of tests to not run, applied after --include (default "^$")
+      --exclude string   Regular expression of subset of tests to not run, applied after --include
+                          (default "^$")
       --in-order         Do not randomize test order
       --include string   Regular expression of subset of tests to run (default "_test\\.sh$")
       --json             Output in JSON format
@@ -24,3 +26,11 @@ Flags:
 Global Flags:
       --config string   config file (default is $HOME/.test-brain.yaml)
 ```
+
+## Marking tests as skipped
+
+Sometimes a test may be marked as skipped, which indicates it didn't fail neither succeeded. It may
+happen, e.g., when external dependencies as not satisfied.
+
+Any test that returns the status code `200` will be marked as skipped. It allows the test itself to
+run checks to determine if it should skip or not.

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -22,14 +22,11 @@ const (
 )
 
 var (
-	// Green is a convenient color helper.
-	Green = color.New(color.FgGreen).SprintfFunc()
-	// GreenBold is a convenient color helper.
-	GreenBold = color.New(color.FgGreen, color.Bold).SprintfFunc()
-	// Red is a convenient color helper.
-	Red = color.New(color.FgRed).SprintfFunc()
-	// RedBold is a convenient color helper.
-	RedBold = color.New(color.FgRed, color.Bold).SprintfFunc()
+	green      = color.New(color.FgGreen).SprintfFunc()
+	greenBold  = color.New(color.FgGreen, color.Bold).SprintfFunc()
+	yellowBold = color.New(color.FgYellow, color.Bold).SprintfFunc()
+	red        = color.New(color.FgRed).SprintfFunc()
+	redBold    = color.New(color.FgRed, color.Bold).SprintfFunc()
 )
 
 // RunnerOptions represents options passed to the Runner.
@@ -317,9 +314,9 @@ func (r *Runner) getErrorCode(err error, command *exec.Cmd) (int, error) {
 func (r *Runner) printVerboseSingleTestResult(result TestResult) {
 	if !r.options.JSONOutput {
 		if result.Success {
-			fmt.Fprintf(r.stdout, "%s: %s\n", Green("PASSED"), result.TestFile)
+			fmt.Fprintf(r.stdout, "%s: %s\n", greenBold("PASSED"), result.TestFile)
 		} else {
-			fmt.Fprintf(r.stderr, "%s: %s\n", RedBold("FAILED"), result.TestFile)
+			fmt.Fprintf(r.stderr, "%s: %s\n", redBold("FAILED"), result.TestFile)
 			if !r.options.Verbose {
 				fmt.Fprintln(r.stderr, "Test output:")
 				io.Copy(r.stderr, result.Output)
@@ -338,15 +335,15 @@ func (r *Runner) collectFailedTestResults() {
 
 func (r *Runner) outputResults() {
 	for _, failedResult := range r.failedTestResults {
-		fmt.Fprintf(r.stderr, RedBold("%s: Failed with exit code %d\n", failedResult.TestFile, failedResult.ExitCode))
+		fmt.Fprintf(r.stderr, redBold("%s: Failed with exit code %d\n", failedResult.TestFile, failedResult.ExitCode))
 	}
 	nbTestsFailed := len(r.failedTestResults)
 	nbTestsPassed := len(r.testResults) - nbTestsFailed
 	summaryString := fmt.Sprintf("\nTests complete: %d Passed, %d Failed", nbTestsPassed, nbTestsFailed)
 	if nbTestsFailed > 0 {
-		fmt.Fprintln(r.stderr, RedBold(summaryString))
+		fmt.Fprintln(r.stderr, redBold(summaryString))
 	} else {
-		fmt.Fprintln(r.stdout, GreenBold(summaryString))
+		fmt.Fprintln(r.stdout, greenBold(summaryString))
 	}
 	if !r.options.InOrder {
 		fmt.Fprintf(r.stdout, "Seed used: %d\n", r.options.RandomSeed)
@@ -379,7 +376,7 @@ func (r *Runner) outputResultsJSON() {
 	jsonEncoder := json.NewEncoder(r.stdout)
 	err := jsonEncoder.Encode(jsonOutputStruct)
 	if err != nil {
-		fmt.Fprintln(r.stderr, RedBold("Error trying to marshal JSON output"))
+		fmt.Fprintln(r.stderr, redBold("Error trying to marshal JSON output"))
 	}
 }
 

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -76,9 +76,6 @@ func (r *Runner) RunCommand() error {
 	}
 	if !r.options.JSONOutput {
 		fmt.Fprintf(r.stdout, "Found %d test files\n", len(testFiles))
-		if !r.options.InOrder {
-			fmt.Fprintf(r.stdout, "Using seed: %d\n", r.options.RandomSeed)
-		}
 	}
 	if r.options.DryRun {
 		if !r.options.JSONOutput {
@@ -358,9 +355,6 @@ func (r *Runner) outputResults() {
 		fmt.Fprintln(r.stderr, redBold(summaryString))
 	} else {
 		fmt.Fprintln(r.stdout, greenBold(summaryString))
-	}
-	if !r.options.InOrder {
-		fmt.Fprintf(r.stdout, "Seed used: %d\n", r.options.RandomSeed)
 	}
 }
 

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	unknownExitCode  = -1
-	skipTestExitCode = 200
+	skipTestExitCode = 99
 )
 
 var (

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -49,9 +49,6 @@ type Runner struct {
 	stdout io.Writer
 
 	options RunnerOptions
-
-	testResults       []TestResult
-	failedTestResults []TestResult
 }
 
 // NewRunner constructs a new Runner.
@@ -88,17 +85,16 @@ func (r *Runner) RunCommand() error {
 		return nil
 	}
 
-	r.runAllTests(testFiles, testRoot)
-	r.collectFailedTestResults()
+	passedResults, skippedResults, failedResults := r.runAllTests(testFiles, testRoot)
 	if r.options.JSONOutput {
-		r.outputResultsJSON()
+		r.outputResultsJSON(passedResults, skippedResults, failedResults)
 	} else {
-		r.outputResults()
+		r.outputResults(passedResults, skippedResults, failedResults)
 	}
-	if len(r.failedTestResults) == 0 {
+	if len(failedResults) == 0 {
 		return nil
 	}
-	return fmt.Errorf("%d tests failed", len(r.failedTestResults))
+	return fmt.Errorf("%d tests failed", len(failedResults))
 }
 
 func (r *Runner) getTestScriptsWithOrder() (string, []string, error) {
@@ -214,35 +210,56 @@ func (r *Runner) shuffleOrder(list []string) {
 	}
 }
 
-func (r *Runner) runAllTests(testFiles []string, testFolder string) {
+func (r *Runner) runAllTests(testFiles []string, testFolder string) ([]PassedResult, []SkippedResult, []FailedResult) {
+	passedResults := make([]PassedResult, 0)
+	skippedResults := make([]SkippedResult, 0)
+	failedResults := make([]FailedResult, 0)
 	for i, testFile := range testFiles {
 		if !r.options.JSONOutput {
 			fmt.Fprintf(r.stdout, "Running test %s (%d/%d)\n", testFile, i+1, len(testFiles))
 		}
-		result := r.runSingleTest(testFile, testFolder)
-		r.printVerboseSingleTestResult(result)
-		r.testResults = append(r.testResults, result)
+
+		var cmdStdout, cmdStderr io.Writer
+		var outputBuf bytes.Buffer
+		if r.options.Verbose {
+			cmdStdout = r.stdout
+			cmdStderr = r.stderr
+		} else {
+			cmdStdout = &outputBuf
+			cmdStderr = &outputBuf
+		}
+		exitCode := r.runSingleTest(testFile, testFolder, cmdStdout, cmdStderr)
+
+		if exitCode == skipTestExitCode {
+			result := SkippedResult{testFile}
+			skippedResults = append(skippedResults, result)
+			fmt.Fprintln(r.stdout, result)
+		} else if exitCode == 0 {
+			result := PassedResult{testFile}
+			passedResults = append(passedResults, result)
+			fmt.Fprintln(r.stdout, result)
+		} else {
+			result := FailedResult{
+				TestResult{testFile},
+				exitCode,
+			}
+			failedResults = append(failedResults, result)
+			fmt.Fprintln(r.stdout, result)
+			if !r.options.Verbose {
+				fmt.Fprintln(r.stdout, "Test output:")
+				io.Copy(r.stdout, &outputBuf)
+			}
+		}
 	}
+	return passedResults, skippedResults, failedResults
 }
 
-func (r *Runner) runSingleTest(testFile string, testFolder string) TestResult {
+func (r *Runner) runSingleTest(testFile string, testFolder string, cmdStdout, cmdStderr io.Writer) (exitCode int) {
 	testPath := filepath.Join(testFolder, testFile)
 
 	command := exec.Command(testPath)
-
-	testResult := TestResult{
-		TestFile: testFile,
-	}
-
-	if r.options.Verbose {
-		command.Stdout = r.stdout
-		command.Stderr = r.stderr
-	} else {
-		var buf bytes.Buffer
-		command.Stdout = &buf
-		command.Stderr = &buf
-		testResult.Output = &buf
-	}
+	command.Stdout = cmdStdout
+	command.Stderr = cmdStderr
 
 	// Propagate timeout information from brain to script, via the environment of the script.
 	env := os.Environ()
@@ -252,9 +269,7 @@ func (r *Runner) runSingleTest(testFile string, testFolder string) TestResult {
 	err := command.Start()
 	if err != nil {
 		fmt.Fprintf(r.stderr, "Test failed: %v", err)
-		testResult.Success = false
-		testResult.ExitCode = unknownExitCode
-		return testResult
+		return unknownExitCode
 	}
 
 	done := make(chan error)
@@ -269,21 +284,15 @@ func (r *Runner) runSingleTest(testFile string, testFolder string) TestResult {
 	case <-timeout:
 		command.Process.Kill()
 		fmt.Fprintf(r.stderr, "Killed by testbrain: Timed out after %v\n", r.options.Timeout)
-		testResult.Success = false
-		testResult.ExitCode = unknownExitCode
+		return unknownExitCode
 	case err = <-done:
-		testResult.ExitCode, err = r.getErrorCode(err, command)
+		exitCode, err = r.getErrorCode(err, command)
 		if err != nil {
 			fmt.Fprintf(r.stderr, "Test failed: %v", err)
-			testResult.Success = false
-			testResult.ExitCode = unknownExitCode
-			return testResult
+			return
 		}
-		testResult.Skipped = (testResult.ExitCode == skipTestExitCode)
-		testResult.Success = command.ProcessState.Success()
 	}
-
-	return testResult
+	return
 }
 
 func (r *Runner) getErrorCode(err error, command *exec.Cmd) (int, error) {
@@ -310,75 +319,58 @@ func (r *Runner) getErrorCode(err error, command *exec.Cmd) (int, error) {
 	return unknownExitCode, nil
 }
 
-func (r *Runner) printVerboseSingleTestResult(result TestResult) {
-	if !r.options.JSONOutput {
-		if result.Skipped {
-			fmt.Fprintf(r.stdout, "%s: %s\n", yellowBold("SKIPPED"), result.TestFile)
-		} else if result.Success {
-			fmt.Fprintf(r.stdout, "%s: %s\n", greenBold("PASSED"), result.TestFile)
-		} else {
-			fmt.Fprintf(r.stderr, "%s: %s\n", redBold("FAILED"), result.TestFile)
-			if !r.options.Verbose {
-				fmt.Fprintln(r.stderr, "Test output:")
-				io.Copy(r.stderr, result.Output)
-			}
-		}
-	}
-}
-
-func (r *Runner) collectFailedTestResults() {
-	for _, result := range r.testResults {
-		if !result.Success && !result.Skipped {
-			r.failedTestResults = append(r.failedTestResults, result)
-		}
-	}
-}
-
-func (r *Runner) outputResults() {
-	for _, failedResult := range r.failedTestResults {
-		fmt.Fprintf(r.stderr, redBold("%s: Failed with exit code %d\n", failedResult.TestFile, failedResult.ExitCode))
-	}
-	var nbTestsPassed uint16
-	var nbTestsSkipped uint16
-	for _, result := range r.testResults {
-		if result.Skipped {
-			nbTestsSkipped++
-		} else if result.Success {
-			nbTestsPassed++
-		}
-	}
-	nbTestsFailed := len(r.failedTestResults)
+func (r *Runner) outputResults(passedResults []PassedResult, skippedResults []SkippedResult, failedResults []FailedResult) {
 	summaryString := fmt.Sprintf(
-		"\nTests complete: %d Passed, %d Skipped, %d Failed",
-		nbTestsPassed, nbTestsSkipped, nbTestsFailed)
-	if nbTestsFailed > 0 {
-		fmt.Fprintln(r.stderr, redBold(summaryString))
+		"Tests complete: %d Passed, %d Skipped, %d Failed",
+		len(passedResults), len(skippedResults), len(failedResults))
+	if len(failedResults) > 0 {
+		fmt.Fprintf(r.stdout, "%s\n\n", redBold(summaryString))
 	} else {
-		fmt.Fprintln(r.stdout, greenBold(summaryString))
+		fmt.Fprintf(r.stdout, "%s\n\n", greenBold(summaryString))
+	}
+
+	if len(skippedResults) > 0 {
+		fmt.Fprintln(r.stdout, "  Skipped tests:")
+		for _, result := range skippedResults {
+			fmt.Fprintf(r.stdout, "    %s\n", result.TestFile)
+		}
+		fmt.Fprintf(r.stdout, "\n")
+	}
+
+	if len(failedResults) > 0 {
+		fmt.Fprintln(r.stdout, "  Failed tests:")
+		for _, result := range failedResults {
+			fmt.Fprintf(r.stdout, "    %s with exit code %d\n", result.TestFile, result.ExitCode)
+		}
+		fmt.Fprintf(r.stdout, "\n")
 	}
 }
 
-func (r *Runner) outputResultsJSON() {
+func (r *Runner) outputResultsJSON(passedResults []PassedResult, skippedResults []SkippedResult, failedResults []FailedResult) {
 	displayedSeed := r.options.RandomSeed
 	if r.options.InOrder {
 		displayedSeed = unknownExitCode
 	}
-	nbTestsFailed := len(r.failedTestResults)
-	nbTestsPassed := len(r.testResults) - nbTestsFailed
 
 	// This is the only place where we need this struct, so anonymous struct seems appropriate.
 	jsonOutputStruct := struct {
-		Passed     int          `json:"passed"`
-		Failed     int          `json:"failed"`
-		Seed       int64        `json:"seed"`
-		InOrder    bool         `json:"inOrder"`
-		FailedList []TestResult `json:"failedList"`
+		Passed      int             `json:"passed"`
+		Skipped     int             `json:"skipped"`
+		Failed      int             `json:"failed"`
+		Seed        int64           `json:"seed"`
+		InOrder     bool            `json:"inOrder"`
+		PassedList  []PassedResult  `json:"passedList"`
+		SkippedList []SkippedResult `json:"skippedList"`
+		FailedList  []FailedResult  `json:"failedList"`
 	}{
-		Passed:     nbTestsPassed,
-		Failed:     nbTestsFailed,
-		Seed:       displayedSeed,
-		InOrder:    r.options.InOrder,
-		FailedList: r.failedTestResults,
+		Passed:      len(passedResults),
+		Skipped:     len(skippedResults),
+		Failed:      len(failedResults),
+		Seed:        displayedSeed,
+		InOrder:     r.options.InOrder,
+		PassedList:  passedResults,
+		SkippedList: skippedResults,
+		FailedList:  failedResults,
 	}
 
 	jsonEncoder := json.NewEncoder(r.stdout)
@@ -390,9 +382,29 @@ func (r *Runner) outputResultsJSON() {
 
 // TestResult contains the result of a single test script.
 type TestResult struct {
-	TestFile string    `json:"filename"`
-	Success  bool      `json:"success"`
-	Skipped  bool      `json:"skipped"`
-	ExitCode int       `json:"exitcode"`
-	Output   io.Reader `json:"-"`
+	TestFile string `json:"filename"`
+}
+
+// PassedResult is a type for a test result that passed.
+type PassedResult TestResult
+
+func (result PassedResult) String() string {
+	return fmt.Sprintf("%s: %s\n", greenBold("PASSED"), result.TestFile)
+}
+
+// SkippedResult is a type for a test result that skipped.
+type SkippedResult TestResult
+
+func (result SkippedResult) String() string {
+	return fmt.Sprintf("%s: %s\n", yellowBold("SKIPPED"), result.TestFile)
+}
+
+// FailedResult is a type for a test result that failed.
+type FailedResult struct {
+	TestResult
+	ExitCode int `json:"exitcode"`
+}
+
+func (result FailedResult) String() string {
+	return fmt.Sprintf("%s: %s\n", redBold("FAILED"), result.TestFile)
 }

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -73,6 +73,9 @@ func (r *Runner) RunCommand() error {
 	}
 	if !r.options.JSONOutput {
 		fmt.Fprintf(r.stdout, "Found %d test files\n", len(testFiles))
+		if !r.options.InOrder {
+			fmt.Fprintf(r.stdout, "Using seed: %d\n", r.options.RandomSeed)
+		}
 	}
 	if r.options.DryRun {
 		if !r.options.JSONOutput {

--- a/lib/runner_test.go
+++ b/lib/runner_test.go
@@ -37,6 +37,8 @@ func setupDefaultRunner() (*Runner, io.ReadWriter, io.ReadWriter) {
 	var stdout concurrentBuffer
 	var stderr concurrentBuffer
 	runner := NewRunner(
+		// io.MultiWriter(&stdout, os.Stdout),
+		// io.MultiWriter(&stderr, os.Stderr),
 		&stdout,
 		&stderr,
 		options,
@@ -92,7 +94,7 @@ func TestGetTestScripts(t *testing.T) {
 	}
 	expected := []string{"000_script_test.sh", "001_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -113,7 +115,7 @@ func TestGetTestScripts_IncludeFilters(t *testing.T) {
 	}
 	expected := []string{"000_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -139,7 +141,7 @@ func TestGetTestScripts_IncludeFiltersMultiFolder(t *testing.T) {
 		"testfolder3-many-tests/000_script_test.sh",
 	}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -160,7 +162,7 @@ func TestGetTestScripts_IncludeFiltersNoMatch(t *testing.T) {
 	}
 
 	if len(testScripts) > 0 {
-		t.Errorf("Expected: []\nHave:     %v\n", testScripts)
+		t.Errorf("\nExpected:\n[]\nHave:\n%v\n", testScripts)
 	}
 }
 
@@ -182,7 +184,7 @@ func TestGetTestScripts_IncludeFiltersMultiFolderNoMatch(t *testing.T) {
 		t.Errorf("Test root '%s' was not '%s'", testRoot, expectedRoot)
 	}
 	if len(testScripts) > 0 {
-		t.Errorf("Expected: []\nHave:     %v\n", testScripts)
+		t.Errorf("\nExpected:\n[]\nHave:\n%v\n", testScripts)
 	}
 }
 
@@ -203,7 +205,7 @@ func TestGetTestScripts_ExcludeFilters(t *testing.T) {
 	}
 	expected := []string{"000_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -223,7 +225,7 @@ func TestGetTestScripts_NestedDirectories(t *testing.T) {
 	}
 	expected := []string{"nested_directory/test_file_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -244,7 +246,7 @@ func TestGetTestScripts_OnlyOneFile(t *testing.T) {
 	}
 	expected := []string{"hello_world_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Errorf("Expected: %v\nHave:      %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -269,7 +271,7 @@ func TestGetTestScripts_NotIncludedExplicit(t *testing.T) {
 	}
 	expected := []string{"000_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -294,7 +296,7 @@ func TestGetTestScripts_OnlyOneResult(t *testing.T) {
 	}
 	expected := []string{"000_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -332,7 +334,7 @@ func TestGetTestScriptsWithOrder_SpecificSeed(t *testing.T) {
 	}
 	expected := []string{"001_script_test.sh", "004_script_test.sh", "002_script_test.sh", "003_script_test.sh", "000_script_test.sh"}
 	if !reflect.DeepEqual(expected, testScripts) {
-		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -350,7 +352,7 @@ func TestGetTestScriptsWithOrder_InOrder(t *testing.T) {
 	}
 	expected := []string{"000_script_test.sh", "001_script_test.sh", "002_script_test.sh", "003_script_test.sh", "004_script_test.sh"}
 	if !reflect.DeepEqual(expected, testScripts) {
-		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("\nExpected:\n%v\nHave:\n%v\n", expected, testScripts)
 	}
 }
 
@@ -468,14 +470,14 @@ func TestRunSingleTestTimeout(t *testing.T) {
 				t.Fatal(err)
 			}
 			if stdoutStr := string(stdoutBytes); stdoutStr != tt.expectedStdout {
-				t.Errorf("Expected stdout:\n %q\n\nHave:\n %q\n", tt.expectedStdout, stdoutStr)
+				t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", tt.expectedStdout, stdoutStr)
 			}
 			stderrBytes, err := ioutil.ReadAll(stderr)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if stderrStr := string(stderrBytes); stderrStr != tt.expectedStderr {
-				t.Errorf("Expected stderr:\n %q\n\nHave:\n %q\n", tt.expectedStderr, stderrStr)
+				t.Errorf("\nExpected stderr:\n%q\n\nHave:\n%q\n", tt.expectedStderr, stderrStr)
 			}
 		})
 	}
@@ -556,14 +558,14 @@ func TestPrintVerboseSingleTestResult(t *testing.T) {
 				t.Fatal(err)
 			}
 			if stdoutStr := string(stdoutBytes); stdoutStr != tt.expectedStdout {
-				t.Errorf("Expected stdout:\n %q\n\nHave:\n %q\n", tt.expectedStdout, stdoutStr)
+				t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", tt.expectedStdout, stdoutStr)
 			}
 			stderrBytes, err := ioutil.ReadAll(stderr)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if stderrStr := string(stderrBytes); stderrStr != tt.expectedStderr {
-				t.Errorf("Expected stderr:\n %q\n\nHave:\n %q\n", tt.expectedStderr, stderrStr)
+				t.Errorf("\nExpected stderr:\n%q\n\nHave:\n%q\n", tt.expectedStderr, stderrStr)
 			}
 		})
 	}
@@ -579,20 +581,20 @@ func TestOutputResults(t *testing.T) {
 	expectedStdout := "Seed used: 42\n"
 	expectedStderr := redBoldString("testfile-failure-1: Failed with exit code 1\n") +
 		redBoldString("testfile-failure-2: Failed with exit code 2\n") +
-		redBoldString("\nTests complete: 2 Passed, 2 Failed\n")
+		redBoldString("\nTests complete: 2 Passed, 0 Skipped, 2 Failed\n")
 	stdoutBytes, err := ioutil.ReadAll(stdout)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stdoutStr := string(stdoutBytes); stdoutStr != expectedStdout {
-		t.Errorf("Expected stdout:\n %q\n\nHave:\n %q\n", expectedStdout, stdoutStr)
+		t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", expectedStdout, stdoutStr)
 	}
 	stderrBytes, err := ioutil.ReadAll(stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stderrStr := string(stderrBytes); stderrStr != expectedStderr {
-		t.Errorf("Expected stderr:\n %q\n\nHave:\n %q\n", expectedStderr, stderrStr)
+		t.Errorf("\nExpected stderr:\n%q\n\nHave:\n%q\n", expectedStderr, stderrStr)
 	}
 }
 
@@ -605,8 +607,8 @@ func TestOutputResultsJSON(t *testing.T) {
 
 	r.outputResultsJSON()
 	expectedStdout := `{"passed":2,"failed":2,"seed":42,"inOrder":false,"failedList":[` +
-		`{"filename":"testfile-failure-1","success":false,"exitcode":1},` +
-		`{"filename":"testfile-failure-2","success":false,"exitcode":2}]}` +
+		`{"filename":"testfile-failure-1","success":false,"skipped":false,"exitcode":1},` +
+		`{"filename":"testfile-failure-2","success":false,"skipped":false,"exitcode":2}]}` +
 		"\n"
 	expectedStderr := ""
 	stdoutBytes, err := ioutil.ReadAll(stdout)
@@ -614,14 +616,14 @@ func TestOutputResultsJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	if stdoutStr := string(stdoutBytes); stdoutStr != expectedStdout {
-		t.Errorf("Expected stdout:\n %q\n\nHave:\n %q\n", expectedStdout, stdoutStr)
+		t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", expectedStdout, stdoutStr)
 	}
 	stderrBytes, err := ioutil.ReadAll(stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stderrStr := string(stderrBytes); stderrStr != expectedStderr {
-		t.Errorf("Expected stderr:\n %q\n\nHave:\n %q\n", expectedStderr, stderrStr)
+		t.Errorf("\nExpected stderr:\n%q\n\nHave:\n%q\n", expectedStderr, stderrStr)
 	}
 }
 
@@ -633,6 +635,68 @@ func TestRunCommandSuccess(t *testing.T) {
 	err := r.RunCommand()
 	if err != nil {
 		t.Errorf("Didn't expect an error, got '%s'", err)
+	}
+}
+
+func TestRunCommandSkip(t *testing.T) {
+	testFolder, _ := filepath.Abs("../testdata/skip")
+
+	tests := []struct {
+		title          string
+		verbose        bool
+		expectedStdout string
+		expectedStderr string
+	}{
+		{
+			title:   "Verbose",
+			verbose: true,
+			expectedStdout: "Found 1 test files\n" +
+				"Using seed: 1552072438299530183\n" +
+				"Running test skip_test.sh (1/1)\n" +
+				"Something stdout\n" +
+				"SKIPPED: skip_test.sh\n\n" +
+				"Tests complete: 0 Passed, 1 Skipped, 0 Failed\n" +
+				"Seed used: 1552072438299530183\n",
+			expectedStderr: "Something stderr\n",
+		},
+		{
+			title:   "Non-verbose",
+			verbose: false,
+			expectedStdout: "Found 1 test files\n" +
+				"Using seed: 1552072438299530183\n" +
+				"Running test skip_test.sh (1/1)\n" +
+				"SKIPPED: skip_test.sh\n\n" +
+				"Tests complete: 0 Passed, 1 Skipped, 0 Failed\n" +
+				"Seed used: 1552072438299530183\n",
+			expectedStderr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			r, stdout, stderr := setupDefaultRunner()
+			r.options.RandomSeed = 1552072438299530183
+			r.options.Verbose = tt.verbose
+			r.options.TestTargets = []string{testFolder}
+			err := r.RunCommand()
+			if err != nil {
+				t.Errorf("Didn't expect an error, got '%s'", err)
+			}
+			stdoutBytes, err := ioutil.ReadAll(stdout)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stdoutStr := string(stdoutBytes); stdoutStr != tt.expectedStdout {
+				t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", tt.expectedStdout, stdoutStr)
+			}
+			stderrBytes, err := ioutil.ReadAll(stderr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stderrStr := string(stderrBytes); stderrStr != tt.expectedStderr {
+				t.Errorf("\nExpected stderr:\n%q\n\nHave:\n%q\n", tt.expectedStderr, stderrStr)
+			}
+		})
 	}
 }
 

--- a/lib/runner_test.go
+++ b/lib/runner_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"path/filepath"
@@ -532,6 +533,7 @@ func TestOutputResultsJSON(t *testing.T) {
 
 func TestRunCommand(t *testing.T) {
 	testFolder, _ := filepath.Abs("../testdata/mixed")
+	seed := int64(1552072438299530183)
 
 	tests := []struct {
 		title          string
@@ -543,6 +545,7 @@ func TestRunCommand(t *testing.T) {
 			title:   "Verbose",
 			verbose: true,
 			expectedStdout: "Found 3 test files\n" +
+				fmt.Sprintf("Using seed: %d\n", seed) +
 				"Running test fail_test.sh (1/3)\n" +
 				"Goodbye World!\n" +
 				"FAILED: fail_test.sh\n\n" +
@@ -563,6 +566,7 @@ func TestRunCommand(t *testing.T) {
 			title:   "Non-verbose",
 			verbose: false,
 			expectedStdout: "Found 3 test files\n" +
+				fmt.Sprintf("Using seed: %d\n", seed) +
 				"Running test fail_test.sh (1/3)\n" +
 				"FAILED: fail_test.sh\n\n" +
 				"Test output:\n" +
@@ -585,7 +589,7 @@ func TestRunCommand(t *testing.T) {
 			var stdout concurrentBuffer
 			var stderr concurrentBuffer
 			r := setupDefaultRunner(&stdout, &stderr)
-			r.options.RandomSeed = 1552072438299530183
+			r.options.RandomSeed = seed
 			r.options.Verbose = tt.verbose
 			r.options.TestTargets = []string{testFolder}
 			err := r.RunCommand()

--- a/lib/runner_test.go
+++ b/lib/runner_test.go
@@ -22,7 +22,7 @@ var (
 	redBoldString = color.New(color.FgRed, color.Bold).SprintfFunc()
 )
 
-func setupDefaultRunner() (*Runner, io.ReadWriter, io.ReadWriter) {
+func setupDefaultRunner(stdout io.Writer, stderr io.Writer) *Runner {
 	options := RunnerOptions{
 		TestTargets:  []string{},
 		IncludeReStr: defaultInclude,
@@ -34,52 +34,57 @@ func setupDefaultRunner() (*Runner, io.ReadWriter, io.ReadWriter) {
 		Verbose:      false,
 		DryRun:       false,
 	}
-	var stdout concurrentBuffer
-	var stderr concurrentBuffer
 	runner := NewRunner(
-		&stdout,
-		&stderr,
+		stdout,
+		stderr,
 		options,
 	)
-	return runner, &stdout, &stderr
+	return runner
 }
 
-func setupTestResults() []TestResult {
-	return append(setupPassedTestResults(), setupFailedTestResults()...)
+func setupPassedTestResults() []PassedResult {
+	return []PassedResult{
+		PassedResult{
+			TestFile: "testfile-success-1",
+		},
+		PassedResult{
+			TestFile: "testfile-success-2",
+		},
+	}
 }
 
-func setupPassedTestResults() []TestResult {
-	passedTestResult1 := TestResult{
-		TestFile: "testfile-success-1",
-		Success:  true,
-		ExitCode: 0,
+func setupSkippedTestResults() []SkippedResult {
+	return []SkippedResult{
+		SkippedResult{
+			TestFile: "testfile-skip-1",
+		},
+		SkippedResult{
+			TestFile: "testfile-skip-2",
+		},
 	}
-	passedTestResult2 := TestResult{
-		TestFile: "testfile-success-2",
-		Success:  true,
-		ExitCode: 0,
-	}
-	return []TestResult{passedTestResult1, passedTestResult2}
 }
 
-func setupFailedTestResults() []TestResult {
-	failedTestResult1 := TestResult{
-		TestFile: "testfile-failure-1",
-		Success:  false,
-		ExitCode: 1,
+func setupFailedTestResults() []FailedResult {
+	return []FailedResult{
+		FailedResult{
+			TestResult: TestResult{
+				TestFile: "testfile-failure-1",
+			},
+			ExitCode: 1,
+		},
+		FailedResult{
+			TestResult: TestResult{
+				TestFile: "testfile-failure-2",
+			},
+			ExitCode: 2,
+		},
 	}
-	failedTestResult2 := TestResult{
-		TestFile: "testfile-failure-2",
-		Success:  false,
-		ExitCode: 2,
-	}
-	return []TestResult{failedTestResult1, failedTestResult2}
 }
 
 func TestGetTestScripts(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/testfolder1")
 	r.options.TestTargets = []string{testFolder}
 
@@ -99,7 +104,7 @@ func TestGetTestScripts(t *testing.T) {
 func TestGetTestScripts_IncludeFilters(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/testfolder1")
 	r.options.TestTargets = []string{testFolder}
 	r.options.IncludeReStr = "000"
@@ -120,7 +125,7 @@ func TestGetTestScripts_IncludeFilters(t *testing.T) {
 func TestGetTestScripts_IncludeFiltersMultiFolder(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolderA, _ := filepath.Abs("../testdata/testfolder1")
 	testFolderB, _ := filepath.Abs("../testdata/testfolder3-many-tests")
 	r.options.TestTargets = []string{testFolderA, testFolderB}
@@ -146,7 +151,7 @@ func TestGetTestScripts_IncludeFiltersMultiFolder(t *testing.T) {
 func TestGetTestScripts_IncludeFiltersNoMatch(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/testfolder1")
 	r.options.TestTargets = []string{testFolder}
 	r.options.IncludeReStr = "002" // testfolder1 has only 000 and 001
@@ -167,7 +172,7 @@ func TestGetTestScripts_IncludeFiltersNoMatch(t *testing.T) {
 func TestGetTestScripts_IncludeFiltersMultiFolderNoMatch(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolderA, _ := filepath.Abs("../testdata/testfolder1")
 	testFolderB, _ := filepath.Abs("../testdata/testfolder3-many-tests")
 	r.options.TestTargets = []string{testFolderA, testFolderB}
@@ -190,7 +195,7 @@ func TestGetTestScripts_ExcludeFilters(t *testing.T) {
 	t.Parallel()
 
 	testFolder, _ := filepath.Abs("../testdata/testfolder1")
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	r.options.TestTargets = []string{testFolder}
 	r.options.ExcludeReStr = "001"
 
@@ -210,7 +215,7 @@ func TestGetTestScripts_ExcludeFilters(t *testing.T) {
 func TestGetTestScripts_NestedDirectories(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/testfolder2")
 	r.options.TestTargets = []string{testFolder}
 
@@ -230,7 +235,7 @@ func TestGetTestScripts_NestedDirectories(t *testing.T) {
 func TestGetTestScripts_OnlyOneFile(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/success")
 	testPath := filepath.Join(testFolder, "hello_world_test.sh")
 	r.options.TestTargets = []string{testPath}
@@ -251,7 +256,7 @@ func TestGetTestScripts_OnlyOneFile(t *testing.T) {
 func TestGetTestScripts_NotIncludedExplicit(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/testfolder1")
 	testFiles := []string{
 		filepath.Join(testFolder, "000_script_test.sh"),
@@ -276,7 +281,7 @@ func TestGetTestScripts_NotIncludedExplicit(t *testing.T) {
 func TestGetTestScripts_OnlyOneResult(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/testfolder1")
 	testFiles := []string{
 		filepath.Join(testFolder, "000_script_test.sh"),
@@ -301,7 +306,7 @@ func TestGetTestScripts_OnlyOneResult(t *testing.T) {
 func TestGetTestScriptsWithOrder_SameSeedSameOrder(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/testfolder3-many-tests")
 	r.options.TestTargets = []string{testFolder}
 
@@ -321,7 +326,7 @@ func TestGetTestScriptsWithOrder_SameSeedSameOrder(t *testing.T) {
 func TestGetTestScriptsWithOrder_SpecificSeed(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/testfolder3-many-tests")
 	r.options.TestTargets = []string{testFolder}
 	r.options.RandomSeed = 42
@@ -339,7 +344,7 @@ func TestGetTestScriptsWithOrder_SpecificSeed(t *testing.T) {
 func TestGetTestScriptsWithOrder_InOrder(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/testfolder3-many-tests")
 	r.options.TestTargets = []string{testFolder}
 	r.options.InOrder = true
@@ -357,7 +362,7 @@ func TestGetTestScriptsWithOrder_InOrder(t *testing.T) {
 func TestShuffleOrder(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFiles := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"}
 	originalOrder := make([]string, len(testFiles))
 	copy(originalOrder, testFiles)
@@ -370,36 +375,24 @@ func TestShuffleOrder(t *testing.T) {
 func TestRunSingleTestSuccess(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/success")
 	testFile := "hello_world_test.sh"
-	testResult := r.runSingleTest(testFile, testFolder)
-	if testResult.TestFile != testFile {
-		t.Errorf("\nExpected TestFile: %v\nHave: %v\n", testFile, testResult.TestFile)
-	}
-	if testResult.Success != true {
-		t.Errorf("\nExpected Success: %v\nHave: %v\n", true, testResult.Success)
-	}
-	if testResult.ExitCode != 0 {
-		t.Errorf("\nExpected ExitCode: %v\nHave: %v\n", 0, testResult.ExitCode)
+	exitCode := r.runSingleTest(testFile, testFolder, ioutil.Discard, ioutil.Discard)
+	if exitCode != 0 {
+		t.Errorf("\nExpected ExitCode: %v\nHave: %v\n", 0, exitCode)
 	}
 }
 
 func TestRunSingleTestFailure(t *testing.T) {
 	t.Parallel()
 
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	testFolder, _ := filepath.Abs("../testdata/failure")
 	testFile := "failure_test.sh"
-	testResult := r.runSingleTest(testFile, testFolder)
-	if testResult.TestFile != testFile {
-		t.Errorf("\nExpected TestFile: %v\nHave: %v\n", testFile, testResult.TestFile)
-	}
-	if testResult.Success != false {
-		t.Errorf("\nExpected Success: %v\nHave: %v\n", false, testResult.Success)
-	}
-	if testResult.ExitCode != 42 {
-		t.Errorf("\nExpected ExitCode: %v\nHave: %v\n", 42, testResult.ExitCode)
+	exitCode := r.runSingleTest(testFile, testFolder, ioutil.Discard, ioutil.Discard)
+	if exitCode != 42 {
+		t.Errorf("\nExpected ExitCode: %v\nHave: %v\n", 42, exitCode)
 	}
 }
 
@@ -409,33 +402,26 @@ func TestRunSingleTestTimeout(t *testing.T) {
 	testFile := "timeout_test.sh"
 
 	tests := []struct {
-		title              string
-		verbose            bool
-		expectedTestResult TestResult
-		expectedStdout     string
-		expectedStderr     string
+		title            string
+		verbose          bool
+		expectedExitCode int
+		expectedStdout   string
+		expectedStderr   string
 	}{
 		{
-			title:   "verbose",
-			verbose: true,
-			expectedTestResult: TestResult{
-				TestFile: testFile,
-				Success:  false,
-				ExitCode: unknownExitCode,
-			},
+			title:            "verbose",
+			verbose:          true,
+			expectedExitCode: unknownExitCode,
 			expectedStdout: "Timeout = 1\n" +
 				"Long running process...\n",
 			expectedStderr: "Killed by testbrain: Timed out after 1s\n",
 		},
 		{
-			title:   "non-verbose",
-			verbose: false,
-			expectedTestResult: TestResult{
-				TestFile: testFile,
-				Success:  false,
-				ExitCode: unknownExitCode,
-			},
-			expectedStdout: "",
+			title:            "non-verbose",
+			verbose:          false,
+			expectedExitCode: unknownExitCode,
+			expectedStdout: "Timeout = 1\n" +
+				"Long running process...\n",
 			expectedStderr: "Killed by testbrain: Timed out after 1s\n",
 		},
 	}
@@ -444,121 +430,25 @@ func TestRunSingleTestTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.title, func(t *testing.T) {
-			r, stdout, stderr := setupDefaultRunner()
+			var stdout concurrentBuffer
+			var stderr concurrentBuffer
+			r := setupDefaultRunner(&stdout, &stderr)
 			r.options.Timeout = 1 * time.Second
 			r.options.Verbose = tt.verbose
 
-			testResult := r.runSingleTest(testFile, testFolder)
-			if testResult.TestFile != tt.expectedTestResult.TestFile {
-				t.Errorf(
-					"\nExpected TestFile: %v\nHave: %v\n",
-					tt.expectedTestResult.TestFile, testResult.TestFile)
-			}
-			if testResult.Success != tt.expectedTestResult.Success {
-				t.Errorf("\nExpected Success: %v\nHave: %v\n",
-					tt.expectedTestResult.Success, testResult.Success)
-			}
-			if testResult.ExitCode != tt.expectedTestResult.ExitCode {
-				t.Errorf("\nExpected ExitCode: %v\nHave: %v\n",
-					tt.expectedTestResult.ExitCode, testResult.ExitCode)
+			exitCode := r.runSingleTest(testFile, testFolder, &stdout, &stderr)
+			if exitCode != tt.expectedExitCode {
+				t.Errorf("\nExpected ExitCode: %v\nHave: %v\n", tt.expectedExitCode, exitCode)
 			}
 
-			stdoutBytes, err := ioutil.ReadAll(stdout)
+			stdoutBytes, err := ioutil.ReadAll(&stdout)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if stdoutStr := string(stdoutBytes); stdoutStr != tt.expectedStdout {
 				t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", tt.expectedStdout, stdoutStr)
 			}
-			stderrBytes, err := ioutil.ReadAll(stderr)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if stderrStr := string(stderrBytes); stderrStr != tt.expectedStderr {
-				t.Errorf("\nExpected stderr:\n%q\n\nHave:\n%q\n", tt.expectedStderr, stderrStr)
-			}
-		})
-	}
-}
-
-func TestPrintVerboseSingleTestResult(t *testing.T) {
-	tests := []struct {
-		title          string
-		success        bool
-		json           bool
-		verbose        bool
-		resultOutput   io.Reader
-		expectedStdout string
-		expectedStderr string
-	}{
-		{
-			title:          "Case #1",
-			success:        true,
-			json:           false,
-			verbose:        false,
-			resultOutput:   bytes.NewBufferString("something in the output"),
-			expectedStdout: color.GreenString("PASSED: \n"),
-			expectedStderr: "",
-		},
-		{
-			title:          "Case #2",
-			success:        true,
-			json:           false,
-			verbose:        true,
-			resultOutput:   bytes.NewBufferString("something in the output"),
-			expectedStdout: color.GreenString("PASSED: \n"),
-			expectedStderr: "",
-		},
-		{
-			title:          "Case #3",
-			success:        false,
-			json:           true,
-			verbose:        false,
-			resultOutput:   bytes.NewBufferString("something in the output"),
-			expectedStdout: "",
-			expectedStderr: "",
-		},
-		{
-			title:          "Case #4",
-			success:        false,
-			json:           false,
-			verbose:        true,
-			resultOutput:   bytes.NewBufferString("something in the output"),
-			expectedStdout: "",
-			expectedStderr: color.New(color.FgRed, color.Bold).SprintfFunc()("FAILED: \n"),
-		},
-		{
-			title:          "Case #5",
-			success:        false,
-			json:           false,
-			verbose:        false,
-			resultOutput:   bytes.NewBufferString("something in the output"),
-			expectedStdout: "",
-			expectedStderr: color.New(color.FgRed, color.Bold).SprintfFunc()(
-				"FAILED: \n" +
-					"Test output:\n" +
-					"something in the output"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.title, func(t *testing.T) {
-			result := TestResult{
-				Success: tt.success,
-				Output:  tt.resultOutput,
-			}
-			r, stdout, stderr := setupDefaultRunner()
-			r.options.JSONOutput = tt.json
-			r.options.Verbose = tt.verbose
-			r.printVerboseSingleTestResult(result)
-			stdoutBytes, err := ioutil.ReadAll(stdout)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if stdoutStr := string(stdoutBytes); stdoutStr != tt.expectedStdout {
-				t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", tt.expectedStdout, stdoutStr)
-			}
-			stderrBytes, err := ioutil.ReadAll(stderr)
+			stderrBytes, err := ioutil.ReadAll(&stderr)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -570,24 +460,31 @@ func TestPrintVerboseSingleTestResult(t *testing.T) {
 }
 
 func TestOutputResults(t *testing.T) {
-	r, stdout, stderr := setupDefaultRunner()
+	var stdout concurrentBuffer
+	var stderr concurrentBuffer
+	r := setupDefaultRunner(&stdout, &stderr)
 	r.options.RandomSeed = 42
-	r.testResults = setupTestResults()
-	r.failedTestResults = setupFailedTestResults()
+	passedResults := setupPassedTestResults()
+	skippedResults := setupSkippedTestResults()
+	failedResults := setupFailedTestResults()
 
-	r.outputResults()
-	expectedStdout := "Seed used: 42\n"
-	expectedStderr := redBoldString("testfile-failure-1: Failed with exit code 1\n") +
-		redBoldString("testfile-failure-2: Failed with exit code 2\n") +
-		redBoldString("\nTests complete: 2 Passed, 0 Skipped, 2 Failed\n")
-	stdoutBytes, err := ioutil.ReadAll(stdout)
+	r.outputResults(passedResults, skippedResults, failedResults)
+	expectedStdout := "Tests complete: 2 Passed, 2 Skipped, 2 Failed\n\n" +
+		"  Skipped tests:\n" +
+		"    testfile-skip-1\n" +
+		"    testfile-skip-2\n\n" +
+		"  Failed tests:\n" +
+		"    testfile-failure-1 with exit code 1\n" +
+		"    testfile-failure-2 with exit code 2\n\n"
+	expectedStderr := ""
+	stdoutBytes, err := ioutil.ReadAll(&stdout)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stdoutStr := string(stdoutBytes); stdoutStr != expectedStdout {
 		t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", expectedStdout, stdoutStr)
 	}
-	stderrBytes, err := ioutil.ReadAll(stderr)
+	stderrBytes, err := ioutil.ReadAll(&stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -597,26 +494,34 @@ func TestOutputResults(t *testing.T) {
 }
 
 func TestOutputResultsJSON(t *testing.T) {
-	r, stdout, stderr := setupDefaultRunner()
-	r.failedTestResults = setupFailedTestResults()
+	var stdout concurrentBuffer
+	var stderr concurrentBuffer
+	r := setupDefaultRunner(&stdout, &stderr)
 	r.options.RandomSeed = 42
-	r.testResults = setupTestResults()
-	r.failedTestResults = setupFailedTestResults()
+	passedResults := setupPassedTestResults()
+	skippedResults := setupSkippedTestResults()
+	failedResults := setupFailedTestResults()
 
-	r.outputResultsJSON()
-	expectedStdout := `{"passed":2,"failed":2,"seed":42,"inOrder":false,"failedList":[` +
-		`{"filename":"testfile-failure-1","success":false,"skipped":false,"exitcode":1},` +
-		`{"filename":"testfile-failure-2","success":false,"skipped":false,"exitcode":2}]}` +
-		"\n"
+	r.outputResultsJSON(passedResults, skippedResults, failedResults)
+	expectedStdout := "{" +
+		`"passed":2,` +
+		`"skipped":2,` +
+		`"failed":2,` +
+		`"seed":42,` +
+		`"inOrder":false,` +
+		`"passedList":[{"filename":"testfile-success-1"},{"filename":"testfile-success-2"}],` +
+		`"skippedList":[{"filename":"testfile-skip-1"},{"filename":"testfile-skip-2"}],` +
+		`"failedList":[{"filename":"testfile-failure-1","exitcode":1},{"filename":"testfile-failure-2","exitcode":2}]` +
+		"}\n"
 	expectedStderr := ""
-	stdoutBytes, err := ioutil.ReadAll(stdout)
+	stdoutBytes, err := ioutil.ReadAll(&stdout)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stdoutStr := string(stdoutBytes); stdoutStr != expectedStdout {
 		t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", expectedStdout, stdoutStr)
 	}
-	stderrBytes, err := ioutil.ReadAll(stderr)
+	stderrBytes, err := ioutil.ReadAll(&stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -625,19 +530,8 @@ func TestOutputResultsJSON(t *testing.T) {
 	}
 }
 
-func TestRunCommandSuccess(t *testing.T) {
-	testFolder, _ := filepath.Abs("../testdata/success")
-	r, _, _ := setupDefaultRunner()
-	r.options.TestTargets = []string{testFolder}
-
-	err := r.RunCommand()
-	if err != nil {
-		t.Errorf("Didn't expect an error, got '%s'", err)
-	}
-}
-
-func TestRunCommandSkip(t *testing.T) {
-	testFolder, _ := filepath.Abs("../testdata/skip")
+func TestRunCommand(t *testing.T) {
+	testFolder, _ := filepath.Abs("../testdata/mixed")
 
 	tests := []struct {
 		title          string
@@ -648,46 +542,64 @@ func TestRunCommandSkip(t *testing.T) {
 		{
 			title:   "Verbose",
 			verbose: true,
-			expectedStdout: "Found 1 test files\n" +
-				"Using seed: 1552072438299530183\n" +
-				"Running test skip_test.sh (1/1)\n" +
+			expectedStdout: "Found 3 test files\n" +
+				"Running test fail_test.sh (1/3)\n" +
+				"Goodbye World!\n" +
+				"FAILED: fail_test.sh\n\n" +
+				"Running test success_test.sh (2/3)\n" +
+				"Hello World!\n" +
+				"PASSED: success_test.sh\n\n" +
+				"Running test skip_test.sh (3/3)\n" +
 				"Something stdout\n" +
 				"SKIPPED: skip_test.sh\n\n" +
-				"Tests complete: 0 Passed, 1 Skipped, 0 Failed\n" +
-				"Seed used: 1552072438299530183\n",
+				"Tests complete: 1 Passed, 1 Skipped, 1 Failed\n\n" +
+				"  Skipped tests:\n" +
+				"    skip_test.sh\n\n" +
+				"  Failed tests:\n" +
+				"    fail_test.sh with exit code 42\n\n",
 			expectedStderr: "Something stderr\n",
 		},
 		{
 			title:   "Non-verbose",
 			verbose: false,
-			expectedStdout: "Found 1 test files\n" +
-				"Using seed: 1552072438299530183\n" +
-				"Running test skip_test.sh (1/1)\n" +
+			expectedStdout: "Found 3 test files\n" +
+				"Running test fail_test.sh (1/3)\n" +
+				"FAILED: fail_test.sh\n\n" +
+				"Test output:\n" +
+				"Goodbye World!\n" +
+				"Running test success_test.sh (2/3)\n" +
+				"PASSED: success_test.sh\n\n" +
+				"Running test skip_test.sh (3/3)\n" +
 				"SKIPPED: skip_test.sh\n\n" +
-				"Tests complete: 0 Passed, 1 Skipped, 0 Failed\n" +
-				"Seed used: 1552072438299530183\n",
+				"Tests complete: 1 Passed, 1 Skipped, 1 Failed\n\n" +
+				"  Skipped tests:\n" +
+				"    skip_test.sh\n\n" +
+				"  Failed tests:\n" +
+				"    fail_test.sh with exit code 42\n\n",
 			expectedStderr: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.title, func(t *testing.T) {
-			r, stdout, stderr := setupDefaultRunner()
+			var stdout concurrentBuffer
+			var stderr concurrentBuffer
+			r := setupDefaultRunner(&stdout, &stderr)
 			r.options.RandomSeed = 1552072438299530183
 			r.options.Verbose = tt.verbose
 			r.options.TestTargets = []string{testFolder}
 			err := r.RunCommand()
-			if err != nil {
-				t.Errorf("Didn't expect an error, got '%s'", err)
+			if err == nil {
+				t.Errorf("Expected an error, got nothing")
 			}
-			stdoutBytes, err := ioutil.ReadAll(stdout)
+			stdoutBytes, err := ioutil.ReadAll(&stdout)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if stdoutStr := string(stdoutBytes); stdoutStr != tt.expectedStdout {
 				t.Errorf("\nExpected stdout:\n%q\n\nHave:\n%q\n", tt.expectedStdout, stdoutStr)
 			}
-			stderrBytes, err := ioutil.ReadAll(stderr)
+			stderrBytes, err := ioutil.ReadAll(&stderr)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -700,7 +612,7 @@ func TestRunCommandSkip(t *testing.T) {
 
 func TestRunCommandFailure(t *testing.T) {
 	testFolder, _ := filepath.Abs("../testdata/failure")
-	r, _, _ := setupDefaultRunner()
+	r := setupDefaultRunner(ioutil.Discard, ioutil.Discard)
 	r.options.TestTargets = []string{testFolder}
 
 	err := r.RunCommand()

--- a/lib/runner_test.go
+++ b/lib/runner_test.go
@@ -85,14 +85,14 @@ func TestGetTestScripts(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	if testFolder != testRoot {
-		t.Fatalf("Test root '%s' was not '%s'", testRoot, testFolder)
+		t.Errorf("Test root '%s' was not '%s'", testRoot, testFolder)
 	}
 	expected := []string{"000_script_test.sh", "001_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Fatalf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
 	}
 }
 
@@ -106,14 +106,14 @@ func TestGetTestScripts_IncludeFilters(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	if testFolder != testRoot {
-		t.Fatalf("Test root '%s' was not '%s'", testRoot, testFolder)
+		t.Errorf("Test root '%s' was not '%s'", testRoot, testFolder)
 	}
 	expected := []string{"000_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Fatalf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
 	}
 }
 
@@ -128,18 +128,18 @@ func TestGetTestScripts_IncludeFiltersMultiFolder(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	expectedRoot := "testdata"
 	if expectedRoot != filepath.Base(testRoot) {
-		t.Fatalf("Test root %s was not %s", testRoot, expectedRoot)
+		t.Errorf("Test root %s was not %s", testRoot, expectedRoot)
 	}
 	expected := []string{
 		"testfolder1/000_script_test.sh",
 		"testfolder3-many-tests/000_script_test.sh",
 	}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Fatalf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
 	}
 }
 
@@ -153,14 +153,14 @@ func TestGetTestScripts_IncludeFiltersNoMatch(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	if testFolder != testRoot {
-		t.Fatalf("Test root %s was not %s", testRoot, testFolder)
+		t.Errorf("Test root %s was not %s", testRoot, testFolder)
 	}
 
 	if len(testScripts) > 0 {
-		t.Fatalf("Expected: []\nHave:     %v\n", testScripts)
+		t.Errorf("Expected: []\nHave:     %v\n", testScripts)
 	}
 }
 
@@ -175,14 +175,14 @@ func TestGetTestScripts_IncludeFiltersMultiFolderNoMatch(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	expectedRoot := ""
 	if expectedRoot != testRoot {
-		t.Fatalf("Test root '%s' was not '%s'", testRoot, expectedRoot)
+		t.Errorf("Test root '%s' was not '%s'", testRoot, expectedRoot)
 	}
 	if len(testScripts) > 0 {
-		t.Fatalf("Expected: []\nHave:     %v\n", testScripts)
+		t.Errorf("Expected: []\nHave:     %v\n", testScripts)
 	}
 }
 
@@ -196,14 +196,14 @@ func TestGetTestScripts_ExcludeFilters(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	if testFolder != testRoot {
-		t.Fatalf("Test root %s was not %s", testRoot, testFolder)
+		t.Errorf("Test root %s was not %s", testRoot, testFolder)
 	}
 	expected := []string{"000_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Fatalf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
 	}
 }
 
@@ -216,14 +216,14 @@ func TestGetTestScripts_NestedDirectories(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	if testFolder != testRoot {
-		t.Fatalf("Test root %s was not %s", testRoot, testFolder)
+		t.Errorf("Test root %s was not %s", testRoot, testFolder)
 	}
 	expected := []string{"nested_directory/test_file_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Fatalf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
 	}
 }
 
@@ -237,14 +237,14 @@ func TestGetTestScripts_OnlyOneFile(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test script: %s", err)
+		t.Errorf("Error getting test script: %s", err)
 	}
 	if testRoot != testFolder {
-		t.Fatalf("Test root %s was not %s", testRoot, testFolder)
+		t.Errorf("Test root %s was not %s", testRoot, testFolder)
 	}
 	expected := []string{"hello_world_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Fatalf("Expected: %v\nHave:      %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:      %v\n", expected, testScripts)
 	}
 }
 
@@ -262,14 +262,14 @@ func TestGetTestScripts_NotIncludedExplicit(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	if testFolder != testRoot {
-		t.Fatalf("Test root %s was not %s", testRoot, testFolder)
+		t.Errorf("Test root %s was not %s", testRoot, testFolder)
 	}
 	expected := []string{"000_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Fatalf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
 	}
 }
 
@@ -287,14 +287,14 @@ func TestGetTestScripts_OnlyOneResult(t *testing.T) {
 
 	testRoot, testScripts, err := r.getTestScripts()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	if testFolder != testRoot {
-		t.Fatalf("Test root %s was not %s", testRoot, testFolder)
+		t.Errorf("Test root %s was not %s", testRoot, testFolder)
 	}
 	expected := []string{"000_script_test.sh"}
 	if !reflect.DeepEqual(testScripts, expected) {
-		t.Fatalf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
 	}
 }
 
@@ -307,14 +307,14 @@ func TestGetTestScriptsWithOrder_SameSeedSameOrder(t *testing.T) {
 
 	_, testScripts1, err := r.getTestScriptsWithOrder()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	_, testScripts2, err := r.getTestScriptsWithOrder()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	if !reflect.DeepEqual(testScripts1, testScripts2) {
-		t.Fatalf("Different results using the seed %d: %v and %v\n", defaultSeed, testScripts1, testScripts2)
+		t.Errorf("Different results using the seed %d: %v and %v\n", defaultSeed, testScripts1, testScripts2)
 	}
 }
 
@@ -328,11 +328,11 @@ func TestGetTestScriptsWithOrder_SpecificSeed(t *testing.T) {
 
 	_, testScripts, err := r.getTestScriptsWithOrder()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	expected := []string{"001_script_test.sh", "004_script_test.sh", "002_script_test.sh", "003_script_test.sh", "000_script_test.sh"}
 	if !reflect.DeepEqual(expected, testScripts) {
-		t.Fatalf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
 	}
 }
 
@@ -346,11 +346,11 @@ func TestGetTestScriptsWithOrder_InOrder(t *testing.T) {
 
 	_, testScripts, err := r.getTestScriptsWithOrder()
 	if err != nil {
-		t.Fatalf("Error getting test scripts: %s", err)
+		t.Errorf("Error getting test scripts: %s", err)
 	}
 	expected := []string{"000_script_test.sh", "001_script_test.sh", "002_script_test.sh", "003_script_test.sh", "004_script_test.sh"}
 	if !reflect.DeepEqual(expected, testScripts) {
-		t.Fatalf("Expected: %v\nHave:     %v\n", expected, testScripts)
+		t.Errorf("Expected: %v\nHave:     %v\n", expected, testScripts)
 	}
 }
 
@@ -363,7 +363,7 @@ func TestShuffleOrder(t *testing.T) {
 	copy(originalOrder, testFiles)
 	r.shuffleOrder(testFiles)
 	if reflect.DeepEqual(testFiles, originalOrder) {
-		t.Fatalf("Shuffle order did not change: %v\n", testFiles)
+		t.Errorf("Shuffle order did not change: %v\n", testFiles)
 	}
 }
 
@@ -375,13 +375,13 @@ func TestRunSingleTestSuccess(t *testing.T) {
 	testFile := "hello_world_test.sh"
 	testResult := r.runSingleTest(testFile, testFolder)
 	if testResult.TestFile != testFile {
-		t.Fatalf("\nExpected TestFile: %v\nHave: %v\n", testFile, testResult.TestFile)
+		t.Errorf("\nExpected TestFile: %v\nHave: %v\n", testFile, testResult.TestFile)
 	}
 	if testResult.Success != true {
-		t.Fatalf("\nExpected Success: %v\nHave: %v\n", true, testResult.Success)
+		t.Errorf("\nExpected Success: %v\nHave: %v\n", true, testResult.Success)
 	}
 	if testResult.ExitCode != 0 {
-		t.Fatalf("\nExpected ExitCode: %v\nHave: %v\n", 0, testResult.ExitCode)
+		t.Errorf("\nExpected ExitCode: %v\nHave: %v\n", 0, testResult.ExitCode)
 	}
 }
 
@@ -393,13 +393,13 @@ func TestRunSingleTestFailure(t *testing.T) {
 	testFile := "failure_test.sh"
 	testResult := r.runSingleTest(testFile, testFolder)
 	if testResult.TestFile != testFile {
-		t.Fatalf("\nExpected TestFile: %v\nHave: %v\n", testFile, testResult.TestFile)
+		t.Errorf("\nExpected TestFile: %v\nHave: %v\n", testFile, testResult.TestFile)
 	}
 	if testResult.Success != false {
-		t.Fatalf("\nExpected Success: %v\nHave: %v\n", false, testResult.Success)
+		t.Errorf("\nExpected Success: %v\nHave: %v\n", false, testResult.Success)
 	}
 	if testResult.ExitCode != 42 {
-		t.Fatalf("\nExpected ExitCode: %v\nHave: %v\n", 42, testResult.ExitCode)
+		t.Errorf("\nExpected ExitCode: %v\nHave: %v\n", 42, testResult.ExitCode)
 	}
 }
 
@@ -450,16 +450,16 @@ func TestRunSingleTestTimeout(t *testing.T) {
 
 			testResult := r.runSingleTest(testFile, testFolder)
 			if testResult.TestFile != tt.expectedTestResult.TestFile {
-				t.Fatalf(
+				t.Errorf(
 					"\nExpected TestFile: %v\nHave: %v\n",
 					tt.expectedTestResult.TestFile, testResult.TestFile)
 			}
 			if testResult.Success != tt.expectedTestResult.Success {
-				t.Fatalf("\nExpected Success: %v\nHave: %v\n",
+				t.Errorf("\nExpected Success: %v\nHave: %v\n",
 					tt.expectedTestResult.Success, testResult.Success)
 			}
 			if testResult.ExitCode != tt.expectedTestResult.ExitCode {
-				t.Fatalf("\nExpected ExitCode: %v\nHave: %v\n",
+				t.Errorf("\nExpected ExitCode: %v\nHave: %v\n",
 					tt.expectedTestResult.ExitCode, testResult.ExitCode)
 			}
 
@@ -468,14 +468,14 @@ func TestRunSingleTestTimeout(t *testing.T) {
 				t.Fatal(err)
 			}
 			if stdoutStr := string(stdoutBytes); stdoutStr != tt.expectedStdout {
-				t.Fatalf("Expected stdout:\n %q\n\nHave:\n %q\n", tt.expectedStdout, stdoutStr)
+				t.Errorf("Expected stdout:\n %q\n\nHave:\n %q\n", tt.expectedStdout, stdoutStr)
 			}
 			stderrBytes, err := ioutil.ReadAll(stderr)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if stderrStr := string(stderrBytes); stderrStr != tt.expectedStderr {
-				t.Fatalf("Expected stderr:\n %q\n\nHave:\n %q\n", tt.expectedStderr, stderrStr)
+				t.Errorf("Expected stderr:\n %q\n\nHave:\n %q\n", tt.expectedStderr, stderrStr)
 			}
 		})
 	}
@@ -556,14 +556,14 @@ func TestPrintVerboseSingleTestResult(t *testing.T) {
 				t.Fatal(err)
 			}
 			if stdoutStr := string(stdoutBytes); stdoutStr != tt.expectedStdout {
-				t.Fatalf("Expected stdout:\n %q\n\nHave:\n %q\n", tt.expectedStdout, stdoutStr)
+				t.Errorf("Expected stdout:\n %q\n\nHave:\n %q\n", tt.expectedStdout, stdoutStr)
 			}
 			stderrBytes, err := ioutil.ReadAll(stderr)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if stderrStr := string(stderrBytes); stderrStr != tt.expectedStderr {
-				t.Fatalf("Expected stderr:\n %q\n\nHave:\n %q\n", tt.expectedStderr, stderrStr)
+				t.Errorf("Expected stderr:\n %q\n\nHave:\n %q\n", tt.expectedStderr, stderrStr)
 			}
 		})
 	}
@@ -585,14 +585,14 @@ func TestOutputResults(t *testing.T) {
 		t.Fatal(err)
 	}
 	if stdoutStr := string(stdoutBytes); stdoutStr != expectedStdout {
-		t.Fatalf("Expected stdout:\n %q\n\nHave:\n %q\n", expectedStdout, stdoutStr)
+		t.Errorf("Expected stdout:\n %q\n\nHave:\n %q\n", expectedStdout, stdoutStr)
 	}
 	stderrBytes, err := ioutil.ReadAll(stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stderrStr := string(stderrBytes); stderrStr != expectedStderr {
-		t.Fatalf("Expected stderr:\n %q\n\nHave:\n %q\n", expectedStderr, stderrStr)
+		t.Errorf("Expected stderr:\n %q\n\nHave:\n %q\n", expectedStderr, stderrStr)
 	}
 }
 
@@ -614,14 +614,14 @@ func TestOutputResultsJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	if stdoutStr := string(stdoutBytes); stdoutStr != expectedStdout {
-		t.Fatalf("Expected stdout:\n %q\n\nHave:\n %q\n", expectedStdout, stdoutStr)
+		t.Errorf("Expected stdout:\n %q\n\nHave:\n %q\n", expectedStdout, stdoutStr)
 	}
 	stderrBytes, err := ioutil.ReadAll(stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if stderrStr := string(stderrBytes); stderrStr != expectedStderr {
-		t.Fatalf("Expected stderr:\n %q\n\nHave:\n %q\n", expectedStderr, stderrStr)
+		t.Errorf("Expected stderr:\n %q\n\nHave:\n %q\n", expectedStderr, stderrStr)
 	}
 }
 
@@ -632,7 +632,7 @@ func TestRunCommandSuccess(t *testing.T) {
 
 	err := r.RunCommand()
 	if err != nil {
-		t.Fatalf("Didn't expect an error, got '%s'", err)
+		t.Errorf("Didn't expect an error, got '%s'", err)
 	}
 }
 

--- a/lib/runner_test.go
+++ b/lib/runner_test.go
@@ -37,8 +37,6 @@ func setupDefaultRunner() (*Runner, io.ReadWriter, io.ReadWriter) {
 	var stdout concurrentBuffer
 	var stderr concurrentBuffer
 	runner := NewRunner(
-		// io.MultiWriter(&stdout, os.Stdout),
-		// io.MultiWriter(&stderr, os.Stderr),
 		&stdout,
 		&stderr,
 		options,

--- a/testdata/mixed/fail_test.sh
+++ b/testdata/mixed/fail_test.sh
@@ -1,0 +1,1 @@
+../failure/failure_test.sh

--- a/testdata/mixed/skip_test.sh
+++ b/testdata/mixed/skip_test.sh
@@ -1,0 +1,1 @@
+../skip/skip_test.sh

--- a/testdata/mixed/success_test.sh
+++ b/testdata/mixed/success_test.sh
@@ -1,0 +1,1 @@
+../success/hello_world_test.sh

--- a/testdata/skip/skip_test.sh
+++ b/testdata/skip/skip_test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Something stdout" >&1
+echo "Something stderr" >&2
+exit 200

--- a/testdata/skip/skip_test.sh
+++ b/testdata/skip/skip_test.sh
@@ -2,4 +2,4 @@
 
 echo "Something stdout" >&1
 echo "Something stderr" >&2
-exit 200
+exit 99


### PR DESCRIPTION
## Description

Sometimes a test may be marked as skipped, which indicates it neither failed nor succeeded. It may
happen, e.g., when external dependencies are not satisfied.

Any test that returns the status code `99` will be marked as skipped. It allows the test itself to
run checks to determine if it should skip or not.

## Test plan

`make test` should pass as it covers the skipped test cases.